### PR TITLE
🔧[Fix] search api 수정

### DIFF
--- a/config/provider.module.ts
+++ b/config/provider.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { EsConfiguration } from './elasticsearch/configuration';
+
+@Module({
+  providers: [EsConfiguration],
+  exports: [EsConfiguration],
+})
+export class ElasticsearchProviderModule {}

--- a/src/modules/search.ts
+++ b/src/modules/search.ts
@@ -1,7 +1,7 @@
 import { Module } from '@nestjs/common';
 import { ElasticsearchModule } from '@nestjs/elasticsearch';
-import PostsSearchService from "../services/search";
-import PostsController from "../controllers/search";
+import PostsSearchService from '../services/search';
+import PostsController from '../controllers/search';
 
 @Module({
   imports: [ElasticsearchModule.register({

--- a/src/services/search.ts
+++ b/src/services/search.ts
@@ -1,50 +1,50 @@
-import { Injectable } from "@nestjs/common";
-import { ElasticsearchService } from "@nestjs/elasticsearch";
-import { ElasticSearchResult } from "../interface/elasticSearchResult";
-import { integer } from "@elastic/elasticsearch/api/types";
-import { mustTermsQuery, sortQuery } from "../utils/elasticUtils";
+import { Injectable } from '@nestjs/common';
+import { ElasticsearchService } from '@nestjs/elasticsearch';
+import { ElasticSearchResult } from '../interface/elasticSearchResult';
+import { integer } from '@elastic/elasticsearch/api/types';
+import { mustTermsQuery, sortQuery } from '../utils/elasticUtils';
 
 @Injectable()
 export default class PostsSearchService {
-  index = "products-*";
+  index = 'products-*';
 
   constructor(
-    private readonly elasticsearchService: ElasticsearchService
+    private readonly elasticsearchService: ElasticsearchService,
   ) {
   }
 
-  async search(text: string, pageSize: integer, currentPage: integer, brand?: string, eventtype?: string, category?: string,sort?:string, isevent?: integer) {
+  async search(text: string, pageSize: integer, currentPage: integer, brand?: string, eventtype?: string, category?: string, sort?: string) {
     let inputObj = {
       index: this.index,
       body: {
-        "size": 10 * (pageSize || 1),
-        "from": ((currentPage || 1) - 1) * 10,
-        "query": {
-          "bool": {
-            "must": []
-          }
+        'size': 10 * (pageSize || 1),
+        'from': ((currentPage || 1) - 1) * 10,
+        'query': {
+          'bool': {
+            'must': [],
+          },
         },
-        "sort": []
-      }
+        'sort': [],
+      },
     };
-    const mustQuery = mustTermsQuery(text,brand,eventtype,category);
+    const mustQuery = mustTermsQuery(text, brand, eventtype, category);
     const sortingQuery = sortQuery(sort);
 
     inputObj.body.query.bool.must.push(...mustQuery);
-    inputObj.body.sort.push(...sortingQuery);
+    sortingQuery.length > 0 ? inputObj.body.sort.push(...sortingQuery) : "";
 
     const { body } = await this.elasticsearchService.search<ElasticSearchResult>(inputObj);
     const hits = body.hits.hits;
-    const totalValue = body.hits.total["value"];
+    const totalValue = body.hits.total['value'];
     if (totalValue > 0) {
       let resultObj = {};
-      resultObj["pageSize"] = pageSize;
-      resultObj["productCnt"] = totalValue;
-      resultObj["currentPage"] = currentPage;
-      resultObj["list"] = hits.map((item) => item._source);
+      resultObj['pageSize'] = pageSize;
+      resultObj['productCnt'] = totalValue;
+      resultObj['currentPage'] = currentPage;
+      resultObj['list'] = hits.map((item) => item._source);
       return resultObj;
     } else {
-      return "";
+      return '';
     }
 
   }

--- a/src/utils/elasticUtils.ts
+++ b/src/utils/elasticUtils.ts
@@ -4,17 +4,18 @@ moment.tz.setDefault("Asia/Seoul");
 let month = moment().format("MM");
 month = month.slice(0,1) === "0" ? month.slice(1,2) : month;
 
-const mustTermsQuery = (text: string, brand?: string, eventtypeValue?: string, category?: string) => {
+// @ TODO 날짜 관련 미들웨어로 뺴야함 너무 중복되서 사용
+const mustTermsQuery = (text: string, brand?: string, eventtype?: string, category?: string) => {
   const must = [];
   let eventtypeArr:any;
-  if(eventtypeValue && eventtypeValue.split(",").length === 2) {
-    eventtypeArr = eventtypeValue.split(",");
+  if(eventtype && eventtype.split(",").length === 2) {
+    eventtypeArr = eventtype.split(",");
     for(let val in eventtypeArr) {
       eventtypeArr[val] = eventtypeArr[val].replace(" ", "+");
     }
-  } else if(eventtypeValue.length === 3){
+  } else if(eventtype && eventtype.length === 3){
     let tempArray = [];
-    const fixValue = eventtypeValue.replace(" ", "+");
+    const fixValue = eventtype.replace(" ", "+");
     tempArray.push(fixValue)
     eventtypeArr = tempArray;
   }
@@ -76,21 +77,15 @@ const sortQuery = (inputSort: string) => {
         }
       });
       break;
-    case("likecnt"):
+    case("viewcnt"):
       sort.push({
-        "likecnt": {
-          "order": "desc"
-        }
+        "viewcnt": {
+          "order": "desc",
+        },
       });
       break;
     default:
-      sort.push({
-        "firstattr": {
-          "order": "desc"
-        }
-      });
   }
   return sort;
 };
-export { mustTermsQuery };
-export { sortQuery };
+export { mustTermsQuery, sortQuery };


### PR DESCRIPTION
1 . eventtype 값을 파라미터로 안넣을때 오류나는 부분 수정
2. 검색 상품결과 정렬시 연관순(default) 에 상품명으로만 나열로 수정
3. 인기순은 likecnt 가 아닌 viewcnt 기준으로 정렬로 수정